### PR TITLE
Changing repo name does not break deployment

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_REPO_NAME=nextjs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,8 @@ jobs:
           npm ci
           npm run build
           npm run export
+        env:
+          NEXT_PUBLIC_REPO_NAME: ${{ github.event.repository.name }}
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.4


### PR DESCRIPTION
The `NEXT_PUBLIC_REPO_NAME` environment variable is now set in the GitHub action rather than a `.env` file, allowing the deployment to work whenever the repo name is changed.