### PR TITLE
Store darkmode preference in local storage and make it flicker free

### DIFF
--- a/components/Navbar/navbar.tsx
+++ b/components/Navbar/navbar.tsx
@@ -4,24 +4,17 @@ import { Style, ThemeContext } from "../../pages/_app";
 import styles from "./navbar.module.css";
 
 export const Navbar = () => {
-  const { theme, setTheme } = useContext(ThemeContext);
+  const { colorMode, setColorMode, setArticleStyle } = useContext(ThemeContext);
 
   return (
     <>
-      <div
-        {...{ "color-mode": theme.darkmode ? "dark" : "light" }}
-        className={styles.navbar}
-      >
-        <button onClick={() => setTheme({ ...theme, style: Style.LaTeX })}>
-          LaTeX
-        </button>
-        <button onClick={() => setTheme({ ...theme, style: Style.GitHub })}>
-          GitHub
-        </button>
+      <div className={styles.navbar}>
+        <button onClick={() => setArticleStyle(Style.LaTeX)}>LaTeX</button>
+        <button onClick={() => setArticleStyle(Style.GitHub)}>GitHub</button>
         <input
           type="checkbox"
-          checked={theme.darkmode}
-          onChange={() => setTheme({ ...theme, darkmode: !theme.darkmode })}
+          checked={colorMode === "dark"}
+          onChange={() => setColorMode(colorMode === "dark" ? "light" : "dark")}
         ></input>
       </div>
       <div style={{ minHeight: "50px" }} />

--- a/components/article.tsx
+++ b/components/article.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export const Article = ({ title, children }: Props) => {
-  const { theme } = useContext(ThemeContext);
+  const { articleStyle } = useContext(ThemeContext);
 
   return (
     <>
@@ -23,11 +23,9 @@ export const Article = ({ title, children }: Props) => {
         />
       </Head>
       <div
-        // Set article dark mode
-        {...{ "color-mode": theme.darkmode ? "dark" : "light" }}
         // Set article style
         className={
-          theme.style === Style.LaTeX
+          articleStyle === Style.LaTeX
             ? latexStyles["markdown-body"]
             : githubStyles["markdown-body"]
         }

--- a/public/theme.js
+++ b/public/theme.js
@@ -1,0 +1,24 @@
+// Big thanks to: https://www.joshwcomeau.com/react/dark-mode/
+
+// The script seems to sometimes run twice. This makes sure it only runs the first time
+if (!document.documentElement.hasAttribute("color-mode")) {
+  const getInitialColorMode = () => {
+    const localStorageColorMode = window.localStorage.getItem("color-mode");
+    const hasStoragePreference = typeof localStorageColorMode === "string";
+    // If the user has explicitly chosen light or dark, use it
+    if (hasStoragePreference) {
+      return localStorageColorMode;
+    }
+    // If they haven't been explicit, check the system preference
+    const query = window.matchMedia("(prefers-color-scheme: dark)");
+    const hasSystemPreference = typeof query.matches === "boolean";
+    if (hasSystemPreference) {
+      return query.matches ? "dark" : "light";
+    }
+    // Default to "light".
+    return "light";
+  };
+
+  const colorMode = getInitialColorMode();
+  document.documentElement.setAttribute("color-mode", colorMode);
+}

--- a/styles/github.module.css
+++ b/styles/github.module.css
@@ -672,7 +672,6 @@
   overflow-wrap: break-word;
   max-width: 1000px; /* we added */
   margin: 1rem auto 0 auto; /* we added */
-  color: var(--color-text-primary); /* we added */
 }
 
 .markdown-body > :first-child {

--- a/styles/global.css
+++ b/styles/global.css
@@ -2,6 +2,8 @@ body {
   margin: 0;
   padding: 0;
   max-width: 100%;
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-primary);
 }
 
 /* Setup LaTeX fonts */

--- a/styles/latex.module.css
+++ b/styles/latex.module.css
@@ -43,7 +43,6 @@
   counter-reset: theorem;
   counter-reset: definition;
   counter-reset: sidenote-counter;
-  color: var(--color-text-primary);
   text-rendering: optimizeLegibility;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "isolatedModules": true,
     "jsx": "preserve"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "*config.js"],
-  "exclude": ["node_modules"]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "*config.js", "public/*.js"],
+  "exclude": ["node_modules", "tests"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,12 @@
     "isolatedModules": true,
     "jsx": "preserve"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "*config.js", "public/*.js"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "*config.js",
+    "public/*.js"
+  ],
   "exclude": ["node_modules", "tests"]
 }


### PR DESCRIPTION
After reading [this page](https://www.joshwcomeau.com/react/dark-mode/), decided to change darkmode state implementation

- Added `public/theme.js` which runs before any HTML is rendered. This
  retrieves the users darkmode preference from local storage and updates
  the `<html>` element to have the correct `color-mode` value which is
  used to update all of the CSS variables.
- Refactored `_app.tsx`:
    - Calls the new `theme.js` script
    - The theme state and context has been split up into `colorMode`
    - and `articleStyle` states which seems a bit cleaner
- Added the `color` and `background-color` CSS attributes to `global.css`
  and removed them from `github.module.css` and `latex.module.css`